### PR TITLE
Customizable text and exe

### DIFF
--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -1,6 +1,10 @@
 import tkinter as tk
 from tkinter import messagebox
 import subprocess
+import json
+
+file = open('settings.json', encoding='utf8')
+settings = json.load(file)
 
 def center_window(window, width_percentage=0.25, height_percentage=0.25):
     window.update_idletasks()
@@ -12,8 +16,8 @@ def center_window(window, width_percentage=0.25, height_percentage=0.25):
 
 def on_yes():
     def check_confirmation(event=None):
-        if entry.get() == "Estudié más de 2 horas hoy":
-            subprocess.run(r'"C:\Riot Games\Riot Client\RiotClientServices.exe" --launch-product=valorant --launch-patchline=live', shell=True)
+        if entry.get() == settings["message"][1]:
+            subprocess.run(rf'{settings["exe_path"]} --launch-product={settings["launch_product"]} --launch-patchline=live', shell=True)
             confirmation_window.destroy()
             root.destroy()
         else:
@@ -22,7 +26,7 @@ def on_yes():
     confirmation_window = tk.Toplevel(root)
     confirmation_window.title("Confirmación")
 
-    label = tk.Label(confirmation_window, text="Ok, confirmá escribiendo la frase:\n\"Estudié más de 2 horas hoy\"", font=("Arial", 12))
+    label = tk.Label(confirmation_window, text=f"Ok, confirmá escribiendo la frase:\n{settings['message'][1]}", font=("Arial", 12))
     label.pack(pady=10)
 
     entry = tk.Entry(confirmation_window, font=("Arial", 12))
@@ -40,7 +44,7 @@ def on_no():
 root = tk.Tk()
 root.title("Recordatorio de Estudio")
 
-label = tk.Label(root, text="¿Ya estudiaste 2 horas hoy?", font=("Arial", 14))
+label = tk.Label(root, text=settings["message"][0], font=("Arial", 14))
 label.pack(pady=20)
 
 button_frame = tk.Frame(root)

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -17,7 +17,7 @@ def center_window(window, width_percentage=0.25, height_percentage=0.25):
 def on_yes():
     def check_confirmation(event=None):
         if entry.get() == settings["message"][1]:
-            subprocess.run(rf'{settings["exe_path"]} --launch-product={settings["launch_product"]} --launch-patchline=live', shell=True)
+            subprocess.run(rf'"{settings["exe_path"]}" --launch-product={settings["launch_product"]} --launch-patchline=live', shell=True)
             confirmation_window.destroy()
             root.destroy()
         else:

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,5 @@
+{
+    "message": ["¿Ya estudiaste 2 horas hoy?", "Estudié más de 2 horas hoy"],
+    "exe_path": "C:\\Riot Games\\Riot Client\\RiotClientServices.exe",
+    "launch_product": "valorant"
+}


### PR DESCRIPTION
Hi!

I hope you are well... I came across this GitHub repo and wanted to contribute 😊

Regarding [Issue#1 Make texts customizable](https://github.com/shizus/compromiso-estudio/issues/1), I've made the following edits:

- Added 'settings.json' file to contain custom messages and file related settings
- Updated 'recordatorio_estudio.py' to read the settings file and write messages accordingly. 

Please note: I don't have Riot Games, so I couldn't test this on other games they have... here are some other parameters I found, that could be tested if you have any of the games installed: 

![image](https://github.com/shizus/compromiso-estudio/assets/65909100/e7b48440-1bdc-47b5-a036-db934045ffd4)


If you could review the contents of these changes, and perhaps test this on other games from Riot Games, that would be great!
Let me know what you think 😊

Thanks,
Kiana