### PR TITLE
Flexibility for non RG applications

### DIFF
--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -19,7 +19,7 @@ def on_yes():
         if entry.get() == settings["message"][1]:
             cmd = rf'"{settings["exe_path"]}"'
 
-            if settings["extra_args"] != "":
+            if "extra_args" in settings.keys():
                 cmd = cmd + settings["extra_args"]
 
             subprocess.run(cmd, shell=True)

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -20,7 +20,7 @@ def on_yes():
             cmd = rf'"{settings["exe_path"]}"'
 
             if "extra_args" in settings.keys():
-                cmd = cmd + settings["extra_args"]
+                cmd = f"{cmd} {settings["extra_args"]}"
 
             subprocess.run(cmd, shell=True)
 

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -20,8 +20,7 @@ def on_yes():
             cmd = rf'"{settings["exe_path"]}"'
 
             if settings["extra_args"] != "":
-                for arg in settings["extra_args"]:
-                    cmd = cmd + arg
+                cmd = cmd + settings["extra_args"]
 
             subprocess.run(cmd, shell=True)
 

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -17,7 +17,12 @@ def center_window(window, width_percentage=0.25, height_percentage=0.25):
 def on_yes():
     def check_confirmation(event=None):
         if entry.get() == settings["message"][1]:
-            subprocess.run(rf'"{settings["exe_path"]}" --launch-product={settings["launch_product"]} --launch-patchline=live', shell=True)
+            cmd = rf'"{settings["exe_path"]}"'
+
+            if settings["riot_game_params"]["launch_product"] != "":
+                cmd = cmd + f'--launch-product={settings["riot_game_params"]["launch_product"]} --launch-patchline=live'
+
+            subprocess.run(cmd, shell=True)
             confirmation_window.destroy()
             root.destroy()
         else:

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -19,12 +19,12 @@ def on_yes():
         if entry.get() == settings["message"][1]:
             cmd = rf'"{settings["exe_path"]}"'
 
-            if settings["riot_game_args"]["launch_product"] != "":
-                cmd = cmd + f'--launch-product={settings["riot_game_args"]["launch_product"]} --launch-patchline=live'
-            elif settings["steam_game_args"]["app_id"] != "":
-                cmd = cmd + f' -applaunch {settings["steam_game_args"]["app_id"]}'
-                
+            if settings["extra_args"] != "":
+                for arg in settings["extra_args"]:
+                    cmd = cmd + arg
+
             subprocess.run(cmd, shell=True)
+
             confirmation_window.destroy()
             root.destroy()
         else:

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -21,7 +21,9 @@ def on_yes():
 
             if settings["riot_game_args"]["launch_product"] != "":
                 cmd = cmd + f'--launch-product={settings["riot_game_args"]["launch_product"]} --launch-patchline=live'
-
+            elif settings["steam_game_args"]["app_id"] != "":
+                cmd = cmd + f' -applaunch {settings["steam_game_args"]["app_id"]}'
+                
             subprocess.run(cmd, shell=True)
             confirmation_window.destroy()
             root.destroy()

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -19,8 +19,8 @@ def on_yes():
         if entry.get() == settings["message"][1]:
             cmd = rf'"{settings["exe_path"]}"'
 
-            if settings["riot_game_params"]["launch_product"] != "":
-                cmd = cmd + f'--launch-product={settings["riot_game_params"]["launch_product"]} --launch-patchline=live'
+            if settings["riot_game_args"]["launch_product"] != "":
+                cmd = cmd + f'--launch-product={settings["riot_game_args"]["launch_product"]} --launch-patchline=live'
 
             subprocess.run(cmd, shell=True)
             confirmation_window.destroy()

--- a/recordatorio_estudio.py
+++ b/recordatorio_estudio.py
@@ -20,7 +20,7 @@ def on_yes():
             cmd = rf'"{settings["exe_path"]}"'
 
             if "extra_args" in settings.keys():
-                cmd = f"{cmd} {settings["extra_args"]}"
+                cmd = f"{cmd} {settings['extra_args']}"
 
             subprocess.run(cmd, shell=True)
 

--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,7 @@
 {
     "message": ["¿Ya estudiaste 2 horas hoy?", "y"],
     "exe_path": "C:\\Windows\\System32\\notepad.exe",
-    "riot_game_params": {
+    "riot_game_args": {
         "launch_product": ""
     }
    

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,9 @@
 {
-    "message": ["¿Ya estudiaste 2 horas hoy?", "Estudié más de 2 horas hoy"],
-    "exe_path": "C:\\Riot Games\\Riot Client\\RiotClientServices.exe",
-    "launch_product": "valorant"
+    "message": ["¿Ya estudiaste 2 horas hoy?", "y"],
+    "exe_path": "C:\\Windows\\System32\\notepad.exe",
+    "riot_game_params": {
+        "launch_product": ""
+    }
+   
 }
+

--- a/settings.json
+++ b/settings.json
@@ -2,6 +2,6 @@
 {
     "message": ["¿Ya estudiaste 2 horas hoy?", "Estudié más de 2 horas hoy"],
     "exe_path": "C:\\Program Files (x86)\\Steam\\steam.exe",
-    "extra_args": [" -applaunch 230410"]
+    "extra_args": " -applaunch 230410"
 }
 

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
-    "message": ["¿Ya estudiaste 2 horas hoy?", "y"],
+    "message": ["¿Ya estudiaste 2 horas hoy?", "I have studied for 2 hrs today"],
     "exe_path": "C:\\Windows\\System32\\notepad.exe",
     "riot_game_args": {
         "launch_product": ""

--- a/settings.json
+++ b/settings.json
@@ -1,9 +1,12 @@
+
 {
-    "message": ["¿Ya estudiaste 2 horas hoy?", "I have studied for 2 hrs today"],
+    "message": ["¿Ya estudiaste 2 horas hoy?", "y"],
     "exe_path": "C:\\Windows\\System32\\notepad.exe",
     "riot_game_args": {
         "launch_product": ""
+    },
+    "steam_game_args": {
+        "app_id":  ""
     }
-   
 }
 

--- a/settings.json
+++ b/settings.json
@@ -2,6 +2,6 @@
 {
     "message": ["¿Ya estudiaste 2 horas hoy?", "Estudié más de 2 horas hoy"],
     "exe_path": "C:\\Program Files (x86)\\Steam\\steam.exe",
-    "extra_args": " -applaunch 230410"
+    "extra_args": ""
 }
 

--- a/settings.json
+++ b/settings.json
@@ -1,12 +1,7 @@
 
 {
-    "message": ["¿Ya estudiaste 2 horas hoy?", "y"],
-    "exe_path": "C:\\Windows\\System32\\notepad.exe",
-    "riot_game_args": {
-        "launch_product": ""
-    },
-    "steam_game_args": {
-        "app_id":  ""
-    }
+    "message": ["¿Ya estudiaste 2 horas hoy?", "Estudié más de 2 horas hoy"],
+    "exe_path": "C:\\Program Files (x86)\\Steam\\steam.exe",
+    "extra_args": [" -applaunch 230410"]
 }
 


### PR DESCRIPTION
Hi!

I've since made some amendments to the settings.json file which enables the Riot Games specific args to be optional and allow user's to run other programs e.g Notepad. 

I would ideally like this to work similar with other game distribution services like Steam, Epic Games, etc... so I have started work on this and included a way to run steam games as well. 

The current settings.json will run Notepad, you can also try C:\\Program Files (x86)\\Steam\\Steam.exe for Steam games (you have to provide an app_id). 

For now, are you happy that this satisfies the requirements for [Issue#3](https://github.com/shizus/compromiso-estudio/issues/3)? Let me know if you want me to expand on this, or if we want to add other options under the same issue ticket.

Thanks,
Kiana 🌼⭐